### PR TITLE
Epic 2.1-2.3 Product catalog frontend pages and componentsFeature/amat/category tree

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,12 +1,39 @@
 <script setup>
-    import Header from './components/Header.vue';
+import { ref } from 'vue'
+
+import CategoryTree from './components/CategoryTree.vue'
+import Header from './components/Header.vue'
+
+const selectedCategory = ref(null)
 </script>
 
 <template>
-  <div class="min-h-screen bg-gray-100 p-8">
-    <h1 class="text-3xl font-bold text-blue-600">
-      Tailwind CSS is working! 🎉
-    </h1>
+  <div class="min-h-screen bg-slate-50 text-slate-950">
+    <Header />
+
+    <main class="mx-auto flex min-h-[calc(100vh-88px)] w-full max-w-7xl border-x border-slate-200 bg-white">
+      <CategoryTree @select="selectedCategory = $event" />
+
+      <section class="min-w-0 flex-1 px-6 py-5">
+        <div class="flex items-center justify-between gap-4 border-b border-slate-200 pb-4">
+          <div>
+            <h1 class="text-xl font-semibold text-slate-950">
+              {{ selectedCategory?.name || 'Product Catalog' }}
+            </h1>
+            <p class="mt-1 text-sm text-slate-500">
+              Tech products for the current store
+            </p>
+          </div>
+        </div>
+
+        <div class="grid gap-4 py-5 sm:grid-cols-2 xl:grid-cols-3">
+          <div
+            v-for="item in 6"
+            :key="item"
+            class="h-36 rounded-md border border-slate-200 bg-slate-50"
+          ></div>
+        </div>
+      </section>
+    </main>
   </div>
-  <Header></Header>
 </template>

--- a/src/App.vue
+++ b/src/App.vue
@@ -3,6 +3,7 @@ import { ref } from 'vue'
 
 import CategoryTree from './components/CategoryTree.vue'
 import Header from './components/Header.vue'
+import VendorProductForm from './components/VendorProductForm.vue'
 
 const selectedCategory = ref(null)
 </script>
@@ -26,12 +27,8 @@ const selectedCategory = ref(null)
           </div>
         </div>
 
-        <div class="grid gap-4 py-5 sm:grid-cols-2 xl:grid-cols-3">
-          <div
-            v-for="item in 6"
-            :key="item"
-            class="h-36 rounded-md border border-slate-200 bg-slate-50"
-          ></div>
+        <div class="py-5">
+          <VendorProductForm />
         </div>
       </section>
     </main>

--- a/src/App.vue
+++ b/src/App.vue
@@ -5,13 +5,16 @@ import CategoryTree from './components/CategoryTree.vue'
 import Header from './components/Header.vue'
 import ProductDetailPage from './components/ProductDetailPage.vue'
 import ProductListingPage from './components/ProductListingPage.vue'
+import VendorProductForm from './components/VendorProductForm.vue'
 
 const selectedCategory = ref(null)
 const selectedProductSlug = ref('')
+const activeView = ref('catalog')
 
 function selectCategory(category) {
   selectedCategory.value = category
   selectedProductSlug.value = ''
+  activeView.value = 'catalog'
 }
 </script>
 
@@ -19,18 +22,44 @@ function selectCategory(category) {
   <div class="min-h-screen bg-slate-50 text-slate-950">
     <Header />
 
-    <main class="mx-auto flex min-h-[calc(100vh-88px)] w-full max-w-7xl border-x border-slate-200 bg-white">
-      <CategoryTree @select="selectCategory" />
-      <ProductDetailPage
-        v-if="selectedProductSlug"
-        :slug="selectedProductSlug"
-        @back="selectedProductSlug = ''"
-      />
-      <ProductListingPage
-        v-else
-        :selected-category="selectedCategory"
-        @view-product="selectedProductSlug = $event"
-      />
-    </main>
+    <div class="mx-auto w-full max-w-7xl border-x border-slate-200 bg-white">
+      <div class="flex justify-end border-b border-slate-200 px-4 py-3">
+        <div class="inline-flex rounded-md border border-slate-200 bg-slate-50 p-1">
+          <button
+            type="button"
+            class="rounded px-3 py-1.5 text-sm font-semibold"
+            :class="activeView === 'catalog' ? 'bg-white text-slate-950 shadow-sm' : 'text-slate-500 hover:text-slate-800'"
+            @click="activeView = 'catalog'"
+          >
+            Catalog
+          </button>
+          <button
+            type="button"
+            class="rounded px-3 py-1.5 text-sm font-semibold"
+            :class="activeView === 'vendor' ? 'bg-white text-slate-950 shadow-sm' : 'text-slate-500 hover:text-slate-800'"
+            @click="activeView = 'vendor'"
+          >
+            Vendor
+          </button>
+        </div>
+      </div>
+
+      <main class="flex min-h-[calc(100vh-137px)] w-full bg-white">
+        <VendorProductForm v-if="activeView === 'vendor'" />
+        <template v-else>
+          <CategoryTree @select="selectCategory" />
+          <ProductDetailPage
+            v-if="selectedProductSlug"
+            :slug="selectedProductSlug"
+            @back="selectedProductSlug = ''"
+          />
+          <ProductListingPage
+            v-else
+            :selected-category="selectedCategory"
+            @view-product="selectedProductSlug = $event"
+          />
+        </template>
+      </main>
+    </div>
   </div>
 </template>

--- a/src/App.vue
+++ b/src/App.vue
@@ -3,9 +3,16 @@ import { ref } from 'vue'
 
 import CategoryTree from './components/CategoryTree.vue'
 import Header from './components/Header.vue'
+import ProductDetailPage from './components/ProductDetailPage.vue'
 import ProductListingPage from './components/ProductListingPage.vue'
 
 const selectedCategory = ref(null)
+const selectedProductSlug = ref('')
+
+function selectCategory(category) {
+  selectedCategory.value = category
+  selectedProductSlug.value = ''
+}
 </script>
 
 <template>
@@ -13,8 +20,17 @@ const selectedCategory = ref(null)
     <Header />
 
     <main class="mx-auto flex min-h-[calc(100vh-88px)] w-full max-w-7xl border-x border-slate-200 bg-white">
-      <CategoryTree @select="selectedCategory = $event" />
-      <ProductListingPage :selected-category="selectedCategory" />
+      <CategoryTree @select="selectCategory" />
+      <ProductDetailPage
+        v-if="selectedProductSlug"
+        :slug="selectedProductSlug"
+        @back="selectedProductSlug = ''"
+      />
+      <ProductListingPage
+        v-else
+        :selected-category="selectedCategory"
+        @view-product="selectedProductSlug = $event"
+      />
     </main>
   </div>
 </template>

--- a/src/App.vue
+++ b/src/App.vue
@@ -3,7 +3,7 @@ import { ref } from 'vue'
 
 import CategoryTree from './components/CategoryTree.vue'
 import Header from './components/Header.vue'
-import VendorProductForm from './components/VendorProductForm.vue'
+import ProductListingPage from './components/ProductListingPage.vue'
 
 const selectedCategory = ref(null)
 </script>
@@ -14,23 +14,7 @@ const selectedCategory = ref(null)
 
     <main class="mx-auto flex min-h-[calc(100vh-88px)] w-full max-w-7xl border-x border-slate-200 bg-white">
       <CategoryTree @select="selectedCategory = $event" />
-
-      <section class="min-w-0 flex-1 px-6 py-5">
-        <div class="flex items-center justify-between gap-4 border-b border-slate-200 pb-4">
-          <div>
-            <h1 class="text-xl font-semibold text-slate-950">
-              {{ selectedCategory?.name || 'Product Catalog' }}
-            </h1>
-            <p class="mt-1 text-sm text-slate-500">
-              Tech products for the current store
-            </p>
-          </div>
-        </div>
-
-        <div class="py-5">
-          <VendorProductForm />
-        </div>
-      </section>
+      <ProductListingPage :selected-category="selectedCategory" />
     </main>
   </div>
 </template>

--- a/src/components/CategoryTree.vue
+++ b/src/components/CategoryTree.vue
@@ -1,0 +1,116 @@
+<script setup>
+import { computed, onMounted, ref } from 'vue'
+
+import CategoryTreeNode from './CategoryTreeNode.vue'
+
+const emit = defineEmits(['select'])
+
+const apiBaseUrl = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000'
+const categories = ref([])
+const expandedIds = ref(new Set())
+const selectedSlug = ref('')
+const isLoading = ref(true)
+const errorMessage = ref('')
+
+const categoryCount = computed(() => countCategories(categories.value))
+
+function countCategories(items) {
+  return items.reduce((total, item) => total + 1 + countCategories(item.children || []), 0)
+}
+
+function setExpandedIds(nextIds) {
+  expandedIds.value = new Set(nextIds)
+}
+
+function collectExpandableIds(items, ids = []) {
+  items.forEach((item) => {
+    if (item.children?.length) {
+      ids.push(item.id)
+      collectExpandableIds(item.children, ids)
+    }
+  })
+  return ids
+}
+
+function toggleCategory(categoryId) {
+  const nextIds = new Set(expandedIds.value)
+
+  if (nextIds.has(categoryId)) {
+    nextIds.delete(categoryId)
+  } else {
+    nextIds.add(categoryId)
+  }
+
+  expandedIds.value = nextIds
+}
+
+function selectCategory(category) {
+  selectedSlug.value = category.slug
+  emit('select', category)
+}
+
+async function loadCategories() {
+  isLoading.value = true
+  errorMessage.value = ''
+
+  try {
+    const response = await fetch(`${apiBaseUrl}/api/v1/catalog/categories/tree/`)
+
+    if (!response.ok) {
+      throw new Error('Could not load categories.')
+    }
+
+    categories.value = await response.json()
+    setExpandedIds(collectExpandableIds(categories.value))
+  } catch (error) {
+    errorMessage.value = error.message || 'Could not load categories.'
+  } finally {
+    isLoading.value = false
+  }
+}
+
+onMounted(loadCategories)
+</script>
+
+<template>
+  <aside class="w-full max-w-72 shrink-0 border-r border-slate-200 bg-white">
+    <div class="flex h-full flex-col">
+      <div class="border-b border-slate-200 px-4 py-4">
+        <div class="flex items-center justify-between gap-3">
+          <h2 class="text-sm font-semibold uppercase tracking-wide text-slate-500">
+            Categories
+          </h2>
+          <span class="rounded-full bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-600">
+            {{ categoryCount }}
+          </span>
+        </div>
+      </div>
+
+      <div class="min-h-0 flex-1 overflow-y-auto p-3">
+        <div v-if="isLoading" class="space-y-2">
+          <div v-for="item in 6" :key="item" class="h-9 animate-pulse rounded-md bg-slate-100"></div>
+        </div>
+
+        <p v-else-if="errorMessage" class="rounded-md bg-red-50 px-3 py-2 text-sm text-red-700">
+          {{ errorMessage }}
+        </p>
+
+        <p v-else-if="!categories.length" class="px-1 py-2 text-sm text-slate-500">
+          No categories found.
+        </p>
+
+        <ul v-else class="space-y-1">
+          <CategoryTreeNode
+            v-for="category in categories"
+            :key="category.id"
+            :category="category"
+            :expanded-ids="expandedIds"
+            :selected-slug="selectedSlug"
+            @toggle="toggleCategory"
+            @select="selectCategory"
+          />
+        </ul>
+      </div>
+    </div>
+  </aside>
+</template>

--- a/src/components/CategoryTreeNode.vue
+++ b/src/components/CategoryTreeNode.vue
@@ -1,0 +1,82 @@
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
+  category: {
+    type: Object,
+    required: true,
+  },
+  depth: {
+    type: Number,
+    default: 0,
+  },
+  expandedIds: {
+    type: Object,
+    required: true,
+  },
+  selectedSlug: {
+    type: String,
+    default: '',
+  },
+})
+
+const emit = defineEmits(['toggle', 'select'])
+
+const hasChildren = computed(() => Boolean(props.category.children?.length))
+const isExpanded = computed(() => props.expandedIds.has(props.category.id))
+const isSelected = computed(() => props.selectedSlug === props.category.slug)
+
+const indentation = computed(() => ({
+  paddingLeft: `${props.depth * 0.875}rem`,
+}))
+</script>
+
+<template>
+  <li>
+    <div
+      class="group flex min-h-10 items-center gap-1 rounded-md pr-2 text-sm transition-colors"
+      :class="isSelected ? 'bg-slate-900 text-white' : 'text-slate-700 hover:bg-slate-100'"
+      :style="indentation"
+    >
+      <button
+        v-if="hasChildren"
+        type="button"
+        class="grid h-8 w-8 shrink-0 place-items-center rounded-md text-base transition-transform hover:bg-black/5"
+        :aria-label="`${isExpanded ? 'Collapse' : 'Expand'} ${category.name}`"
+        :aria-expanded="isExpanded"
+        @click.stop="emit('toggle', category.id)"
+      >
+        <span :class="{ 'rotate-90': isExpanded }" class="block transition-transform">&gt;</span>
+      </button>
+
+      <span v-else class="h-8 w-8 shrink-0" aria-hidden="true"></span>
+
+      <button
+        type="button"
+        class="flex min-w-0 flex-1 items-center gap-2 rounded-md py-2 text-left"
+        @click="emit('select', category)"
+      >
+        <img
+          v-if="category.icon_url"
+          :src="category.icon_url"
+          :alt="`${category.name} icon`"
+          class="h-4 w-4 shrink-0 object-contain"
+        >
+        <span class="truncate">{{ category.name }}</span>
+      </button>
+    </div>
+
+    <ul v-if="hasChildren && isExpanded" class="mt-1 space-y-1">
+      <CategoryTreeNode
+        v-for="child in category.children"
+        :key="child.id"
+        :category="child"
+        :depth="depth + 1"
+        :expanded-ids="expandedIds"
+        :selected-slug="selectedSlug"
+        @toggle="emit('toggle', $event)"
+        @select="emit('select', $event)"
+      />
+    </ul>
+  </li>
+</template>

--- a/src/components/FilterPanel.vue
+++ b/src/components/FilterPanel.vue
@@ -1,0 +1,218 @@
+<script setup>
+import { computed, onMounted, ref, watch } from 'vue'
+
+const props = defineProps({
+  modelValue: {
+    type: Object,
+    default: () => ({}),
+  },
+  facets: {
+    type: Object,
+    default: () => ({
+      brands: [],
+      price_ranges: [],
+    }),
+  },
+})
+
+const emit = defineEmits(['update:modelValue', 'clear'])
+
+const apiBaseUrl = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000'
+const categories = ref([])
+const isLoadingCategories = ref(false)
+const categoryError = ref('')
+const minPrice = ref(Number(props.modelValue.minPrice || 0))
+const maxPrice = ref(Number(props.modelValue.maxPrice || 3000))
+
+const flattenedCategories = computed(() => flattenCategories(categories.value))
+const hasActiveFilters = computed(() => (
+  Boolean(props.modelValue.brand)
+  || Boolean(props.modelValue.category)
+  || Number(props.modelValue.minPrice || 0) > 0
+  || Number(props.modelValue.maxPrice || 3000) < 3000
+))
+
+function flattenCategories(items, depth = 0, output = []) {
+  items.forEach((category) => {
+    output.push({
+      id: category.id,
+      name: category.name,
+      slug: category.slug,
+      depth,
+    })
+    flattenCategories(category.children || [], depth + 1, output)
+  })
+  return output
+}
+
+function updateFilter(key, value) {
+  emit('update:modelValue', {
+    ...props.modelValue,
+    [key]: value,
+  })
+}
+
+function updatePriceRange() {
+  const nextMinPrice = Math.min(Number(minPrice.value), Number(maxPrice.value))
+  const nextMaxPrice = Math.max(Number(minPrice.value), Number(maxPrice.value))
+  minPrice.value = nextMinPrice
+  maxPrice.value = nextMaxPrice
+  emit('update:modelValue', {
+    ...props.modelValue,
+    minPrice: nextMinPrice,
+    maxPrice: nextMaxPrice,
+  })
+}
+
+function toggleBrand(slug) {
+  updateFilter('brand', props.modelValue.brand === slug ? '' : slug)
+}
+
+function clearFilters() {
+  minPrice.value = 0
+  maxPrice.value = 3000
+  emit('clear')
+}
+
+async function loadCategories() {
+  isLoadingCategories.value = true
+  categoryError.value = ''
+
+  try {
+    const response = await fetch(`${apiBaseUrl}/api/v1/catalog/categories/tree/`)
+
+    if (!response.ok) {
+      throw new Error('Could not load categories.')
+    }
+
+    categories.value = await response.json()
+  } catch (error) {
+    categoryError.value = error.message || 'Could not load categories.'
+  } finally {
+    isLoadingCategories.value = false
+  }
+}
+
+watch(
+  () => [props.modelValue.minPrice, props.modelValue.maxPrice],
+  ([nextMinPrice, nextMaxPrice]) => {
+    minPrice.value = Number(nextMinPrice || 0)
+    maxPrice.value = Number(nextMaxPrice || 3000)
+  },
+)
+
+onMounted(loadCategories)
+</script>
+
+<template>
+  <aside class="w-full shrink-0 border-b border-slate-200 bg-white lg:w-72 lg:border-b-0 lg:border-r">
+    <div class="space-y-5 p-4">
+      <div class="flex items-center justify-between gap-3">
+        <h2 class="text-sm font-semibold uppercase text-slate-500">
+          Filters
+        </h2>
+        <button
+          type="button"
+          class="rounded-md border border-slate-200 px-2.5 py-1.5 text-xs font-semibold text-slate-600 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-40"
+          :disabled="!hasActiveFilters"
+          @click="clearFilters"
+        >
+          Clear
+        </button>
+      </div>
+
+      <section class="space-y-3">
+        <div class="flex items-center justify-between">
+          <h3 class="text-sm font-semibold text-slate-900">
+            Price
+          </h3>
+          <span class="text-xs font-medium text-slate-500">
+            ${{ minPrice }} - ${{ maxPrice }}
+          </span>
+        </div>
+
+        <div class="space-y-3">
+          <label class="block text-xs font-medium text-slate-500">
+            Minimum
+            <input
+              v-model.number="minPrice"
+              type="range"
+              min="0"
+              max="3000"
+              step="50"
+              class="mt-2 w-full accent-slate-900"
+              @change="updatePriceRange"
+            >
+          </label>
+          <label class="block text-xs font-medium text-slate-500">
+            Maximum
+            <input
+              v-model.number="maxPrice"
+              type="range"
+              min="0"
+              max="3000"
+              step="50"
+              class="mt-2 w-full accent-slate-900"
+              @change="updatePriceRange"
+            >
+          </label>
+        </div>
+      </section>
+
+      <section class="space-y-3">
+        <h3 class="text-sm font-semibold text-slate-900">
+          Brands
+        </h3>
+        <div v-if="facets.brands?.length" class="space-y-2">
+          <label
+            v-for="brand in facets.brands"
+            :key="brand.slug"
+            class="flex items-center justify-between gap-3 rounded-md border border-slate-200 px-3 py-2 text-sm hover:bg-slate-50"
+          >
+            <span class="flex min-w-0 items-center gap-2">
+              <input
+                type="checkbox"
+                class="h-4 w-4 rounded border-slate-300 text-slate-900"
+                :checked="modelValue.brand === brand.slug"
+                @change="toggleBrand(brand.slug)"
+              >
+              <span class="truncate text-slate-700">{{ brand.name }}</span>
+            </span>
+            <span class="shrink-0 text-xs font-medium text-slate-500">
+              {{ brand.count }}
+            </span>
+          </label>
+        </div>
+        <p v-else class="rounded-md bg-slate-50 px-3 py-2 text-sm text-slate-500">
+          No brand facets yet.
+        </p>
+      </section>
+
+      <section class="space-y-3">
+        <h3 class="text-sm font-semibold text-slate-900">
+          Category
+        </h3>
+        <select
+          class="w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 outline-none focus:border-slate-400"
+          :value="modelValue.category || ''"
+          @change="updateFilter('category', $event.target.value)"
+        >
+          <option value="">All categories</option>
+          <option
+            v-for="category in flattenedCategories"
+            :key="category.id"
+            :value="category.slug"
+          >
+            {{ `${'-- '.repeat(category.depth)}${category.name}` }}
+          </option>
+        </select>
+        <p v-if="isLoadingCategories" class="text-xs text-slate-500">
+          Loading categories...
+        </p>
+        <p v-else-if="categoryError" class="text-xs text-red-600">
+          {{ categoryError }}
+        </p>
+      </section>
+    </div>
+  </aside>
+</template>

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -1,6 +1,6 @@
 <script setup>
     import NavigationBar from './NavigationBar.vue';
-    import Searchbar from './Searchbar.vue';
+    import SearchBar from './SearchBar.vue';
 </script>
 
 <template>
@@ -11,7 +11,7 @@
             </div>
 
             <NavigationBar/>
-            <Searchbar/>
+            <SearchBar/>
             
         </div>
 

--- a/src/components/ProductCard.vue
+++ b/src/components/ProductCard.vue
@@ -1,0 +1,77 @@
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
+  product: {
+    type: Object,
+    required: true,
+  },
+})
+
+const formattedPrice = computed(() => {
+  const numericPrice = Number(props.product.price)
+
+  if (Number.isNaN(numericPrice)) {
+    return props.product.price
+  }
+
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+  }).format(numericPrice)
+})
+
+const ratingLabel = computed(() => {
+  if (props.product.avg_rating === null || props.product.avg_rating === undefined) {
+    return 'New'
+  }
+
+  return Number(props.product.avg_rating).toFixed(1)
+})
+</script>
+
+<template>
+  <article class="flex h-full flex-col overflow-hidden rounded-md border border-slate-200 bg-white transition hover:border-slate-300 hover:shadow-sm">
+    <div class="aspect-[4/3] bg-slate-100">
+      <img
+        v-if="product.thumbnail"
+        :src="product.thumbnail"
+        :alt="product.name"
+        class="h-full w-full object-cover"
+        loading="lazy"
+      >
+      <div v-else class="flex h-full items-center justify-center bg-slate-100 px-4 text-center">
+        <span class="text-sm font-medium text-slate-400">
+          {{ product.name }}
+        </span>
+      </div>
+    </div>
+
+    <div class="flex flex-1 flex-col p-4">
+      <div class="flex items-start justify-between gap-3">
+        <h2 class="min-w-0 text-sm font-semibold leading-5 text-slate-950">
+          {{ product.name }}
+        </h2>
+        <span class="shrink-0 rounded-full bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-600">
+          {{ ratingLabel }}
+        </span>
+      </div>
+
+      <p class="mt-1 truncate text-xs text-slate-500">
+        {{ product.slug }}
+      </p>
+
+      <div class="mt-auto flex items-center justify-between gap-3 pt-4">
+        <p class="text-base font-semibold text-slate-950">
+          {{ formattedPrice }}
+        </p>
+        <button
+          type="button"
+          class="rounded-md border border-slate-200 px-3 py-2 text-xs font-semibold text-slate-700 hover:bg-slate-50"
+        >
+          View
+        </button>
+      </div>
+    </div>
+  </article>
+</template>

--- a/src/components/ProductCard.vue
+++ b/src/components/ProductCard.vue
@@ -8,6 +8,8 @@ const props = defineProps({
   },
 })
 
+const emit = defineEmits(['view'])
+
 const formattedPrice = computed(() => {
   const numericPrice = Number(props.product.price)
 
@@ -68,6 +70,7 @@ const ratingLabel = computed(() => {
         <button
           type="button"
           class="rounded-md border border-slate-200 px-3 py-2 text-xs font-semibold text-slate-700 hover:bg-slate-50"
+          @click="emit('view', product.slug)"
         >
           View
         </button>

--- a/src/components/ProductCard.vue
+++ b/src/components/ProductCard.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed } from 'vue'
+import { computed, ref, watch } from 'vue'
 
 const props = defineProps({
   product: {
@@ -8,7 +8,8 @@ const props = defineProps({
   },
 })
 
-const emit = defineEmits(['view'])
+const emit = defineEmits(['view', 'toggle-wishlist'])
+const isWishlisted = ref(Boolean(props.product.is_wishlisted))
 
 const formattedPrice = computed(() => {
   const numericPrice = Number(props.product.price)
@@ -30,11 +31,23 @@ const ratingLabel = computed(() => {
 
   return Number(props.product.avg_rating).toFixed(1)
 })
+
+function toggleWishlist() {
+  isWishlisted.value = !isWishlisted.value
+  emit('toggle-wishlist', {
+    product: props.product,
+    isWishlisted: isWishlisted.value,
+  })
+}
+
+watch(() => props.product.is_wishlisted, (nextValue) => {
+  isWishlisted.value = Boolean(nextValue)
+})
 </script>
 
 <template>
   <article class="flex h-full flex-col overflow-hidden rounded-md border border-slate-200 bg-white transition hover:border-slate-300 hover:shadow-sm">
-    <div class="aspect-[4/3] bg-slate-100">
+    <div class="relative aspect-[4/3] bg-slate-100">
       <img
         v-if="product.thumbnail"
         :src="product.thumbnail"
@@ -47,6 +60,31 @@ const ratingLabel = computed(() => {
           {{ product.name }}
         </span>
       </div>
+
+      <button
+        type="button"
+        class="absolute right-3 top-3 flex h-9 w-9 items-center justify-center rounded-full border border-white/70 bg-white/90 text-slate-600 shadow-sm transition hover:bg-white hover:text-rose-600"
+        :class="{ 'text-rose-600': isWishlisted }"
+        :aria-pressed="isWishlisted"
+        :aria-label="isWishlisted ? 'Remove from wishlist' : 'Add to wishlist'"
+        @click="toggleWishlist"
+      >
+        <svg
+          class="h-4 w-4"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <path
+            d="M20.8 4.6c-1.5-1.4-3.9-1.4-5.4.1L12 8.1 8.6 4.7C7.1 3.2 4.7 3.1 3.2 4.6c-1.7 1.6-1.7 4.2-.1 5.9l8.9 8.9 8.9-8.9c1.6-1.7 1.6-4.3-.1-5.9Z"
+            :fill="isWishlisted ? 'currentColor' : 'none'"
+          />
+        </svg>
+      </button>
     </div>
 
     <div class="flex flex-1 flex-col p-4">
@@ -55,7 +93,7 @@ const ratingLabel = computed(() => {
           {{ product.name }}
         </h2>
         <span class="shrink-0 rounded-full bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-600">
-          {{ ratingLabel }}
+          {{ ratingLabel === 'New' ? ratingLabel : `${ratingLabel} rating` }}
         </span>
       </div>
 

--- a/src/components/ProductDetailPage.vue
+++ b/src/components/ProductDetailPage.vue
@@ -1,0 +1,229 @@
+<script setup>
+import { computed, onMounted, ref, watch } from 'vue'
+
+const props = defineProps({
+  slug: {
+    type: String,
+    required: true,
+  },
+})
+
+const emit = defineEmits(['back'])
+
+const apiBaseUrl = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000'
+const product = ref(null)
+const selectedImageIndex = ref(0)
+const activeTab = ref('specs')
+const isLoading = ref(false)
+const errorMessage = ref('')
+const addToCartStatus = ref('')
+
+const galleryImages = computed(() => {
+  return (product.value?.images || []).map((image) => ({
+    ...image,
+    src: image.large || image.medium || image.image || image.thumbnail,
+  })).filter((image) => image.src)
+})
+
+const selectedImage = computed(() => galleryImages.value[selectedImageIndex.value] || null)
+
+const formattedPrice = computed(() => {
+  const numericPrice = Number(product.value?.price)
+
+  if (Number.isNaN(numericPrice)) {
+    return product.value?.price || ''
+  }
+
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+  }).format(numericPrice)
+})
+
+const specs = computed(() => Object.entries(product.value?.specs || {}))
+const variants = computed(() => product.value?.variants || [])
+const totalStock = computed(() => {
+  return variants.value.reduce((total, variant) => total + Number(variant.stock_quantity || 0), 0)
+})
+
+async function loadProduct() {
+  isLoading.value = true
+  errorMessage.value = ''
+  addToCartStatus.value = ''
+  selectedImageIndex.value = 0
+  activeTab.value = 'specs'
+
+  try {
+    const response = await fetch(`${apiBaseUrl}/api/v1/catalog/products/${props.slug}/`)
+
+    if (!response.ok) {
+      throw new Error('Could not load product.')
+    }
+
+    product.value = await response.json()
+  } catch (error) {
+    product.value = null
+    errorMessage.value = error.message || 'Could not load product.'
+  } finally {
+    isLoading.value = false
+  }
+}
+
+function addToCart() {
+  addToCartStatus.value = 'Added to cart'
+}
+
+onMounted(loadProduct)
+
+watch(() => props.slug, loadProduct)
+</script>
+
+<template>
+  <section class="min-w-0 flex-1 px-6 py-5">
+    <button
+      type="button"
+      class="mb-4 rounded-md border border-slate-200 px-3 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-50"
+      @click="emit('back')"
+    >
+      Back to products
+    </button>
+
+    <div v-if="isLoading" class="grid gap-6 lg:grid-cols-[minmax(0,1fr)_360px]">
+      <div class="h-[520px] animate-pulse rounded-md bg-slate-100"></div>
+      <div class="space-y-4">
+        <div class="h-8 animate-pulse rounded-md bg-slate-100"></div>
+        <div class="h-24 animate-pulse rounded-md bg-slate-100"></div>
+        <div class="h-12 animate-pulse rounded-md bg-slate-100"></div>
+      </div>
+    </div>
+
+    <div v-else-if="errorMessage" class="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+      {{ errorMessage }}
+    </div>
+
+    <div v-else-if="product" class="grid gap-6 lg:grid-cols-[minmax(0,1fr)_360px]">
+      <div class="min-w-0">
+        <div class="overflow-hidden rounded-md border border-slate-200 bg-slate-100">
+          <img
+            v-if="selectedImage"
+            :src="selectedImage.src"
+            :alt="selectedImage.alt_text || product.name"
+            class="aspect-[4/3] w-full object-cover"
+          >
+          <div v-else class="flex aspect-[4/3] items-center justify-center px-6 text-center text-sm font-medium text-slate-400">
+            {{ product.name }}
+          </div>
+        </div>
+
+        <div v-if="galleryImages.length > 1" class="mt-3 grid grid-cols-4 gap-3 sm:grid-cols-6">
+          <button
+            v-for="(image, index) in galleryImages"
+            :key="image.id"
+            type="button"
+            class="overflow-hidden rounded-md border bg-slate-100"
+            :class="index === selectedImageIndex ? 'border-slate-900 ring-2 ring-slate-900' : 'border-slate-200 hover:border-slate-400'"
+            @click="selectedImageIndex = index"
+          >
+            <img
+              :src="image.thumbnail || image.src"
+              :alt="image.alt_text || product.name"
+              class="aspect-square w-full object-cover"
+            >
+          </button>
+        </div>
+
+        <div class="mt-6 rounded-md border border-slate-200 bg-white">
+          <div class="flex border-b border-slate-200">
+            <button
+              type="button"
+              class="px-4 py-3 text-sm font-semibold"
+              :class="activeTab === 'specs' ? 'border-b-2 border-slate-900 text-slate-950' : 'text-slate-500 hover:text-slate-800'"
+              @click="activeTab = 'specs'"
+            >
+              Specs
+            </button>
+            <button
+              type="button"
+              class="px-4 py-3 text-sm font-semibold"
+              :class="activeTab === 'variants' ? 'border-b-2 border-slate-900 text-slate-950' : 'text-slate-500 hover:text-slate-800'"
+              @click="activeTab = 'variants'"
+            >
+              Variants
+            </button>
+          </div>
+
+          <div class="p-4">
+            <dl v-if="activeTab === 'specs' && specs.length" class="grid gap-3 sm:grid-cols-2">
+              <div
+                v-for="[label, value] in specs"
+                :key="label"
+                class="rounded-md bg-slate-50 px-3 py-2"
+              >
+                <dt class="text-xs font-semibold uppercase text-slate-500">
+                  {{ label }}
+                </dt>
+                <dd class="mt-1 text-sm text-slate-900">
+                  {{ value }}
+                </dd>
+              </div>
+            </dl>
+
+            <p v-else-if="activeTab === 'specs'" class="text-sm text-slate-500">
+              No specs available.
+            </p>
+
+            <div v-else-if="variants.length" class="divide-y divide-slate-200">
+              <div
+                v-for="variant in variants"
+                :key="variant.id"
+                class="grid gap-3 py-3 text-sm sm:grid-cols-4"
+              >
+                <span class="font-medium text-slate-950">{{ variant.color || 'Standard' }}</span>
+                <span class="text-slate-600">{{ variant.storage || 'Storage n/a' }}</span>
+                <span class="text-slate-600">{{ variant.ram || 'RAM n/a' }}</span>
+                <span class="font-medium text-slate-950">{{ variant.stock_quantity }} in stock</span>
+              </div>
+            </div>
+
+            <p v-else class="text-sm text-slate-500">
+              No variants available.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <aside class="h-fit rounded-md border border-slate-200 bg-white p-5">
+        <p class="text-xs font-semibold uppercase text-slate-500">
+          {{ product.brand?.name || 'Brand' }}
+        </p>
+        <h1 class="mt-2 text-2xl font-semibold leading-tight text-slate-950">
+          {{ product.name }}
+        </h1>
+        <p class="mt-2 text-sm text-slate-500">
+          {{ product.category?.name || 'Product' }} / {{ product.sku }}
+        </p>
+
+        <div class="mt-5 flex items-end justify-between gap-4">
+          <p class="text-3xl font-semibold text-slate-950">
+            {{ formattedPrice }}
+          </p>
+          <p class="rounded-full bg-emerald-50 px-3 py-1 text-xs font-semibold text-emerald-700">
+            {{ totalStock }} in stock
+          </p>
+        </div>
+
+        <button
+          type="button"
+          class="mt-5 w-full rounded-md bg-slate-950 px-4 py-3 text-sm font-semibold text-white hover:bg-slate-800"
+          @click="addToCart"
+        >
+          Add to cart
+        </button>
+
+        <p v-if="addToCartStatus" class="mt-3 rounded-md bg-emerald-50 px-3 py-2 text-sm font-medium text-emerald-700">
+          {{ addToCartStatus }}
+        </p>
+      </aside>
+    </div>
+  </section>
+</template>

--- a/src/components/ProductListingPage.vue
+++ b/src/components/ProductListingPage.vue
@@ -15,12 +15,13 @@ const emit = defineEmits(['view-product'])
 
 const apiBaseUrl = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000'
 const defaultFilters = {
+  query: '',
   brand: '',
   category: '',
   minPrice: 0,
   maxPrice: 3000,
 }
-const filterParamKeys = ['brand', 'category', 'min_price', 'max_price']
+const filterParamKeys = ['q', 'brand', 'category', 'min_price', 'max_price']
 const products = ref([])
 const facets = ref({
   brands: [],
@@ -57,6 +58,9 @@ function filtersToSearchParams(filters) {
 
   if (filters.brand) {
     params.set('brand', filters.brand)
+  }
+  if (filters.query) {
+    params.set('q', filters.query)
   }
   if (filters.category) {
     params.set('category', filters.category)
@@ -97,6 +101,7 @@ function readFiltersFromUrl() {
   )
 
   return {
+    query: params.get('q') || defaultFilters.query,
     brand: params.get('brand') || defaultFilters.brand,
     category: params.get('category') || defaultFilters.category,
     minPrice: Math.min(minPrice, maxPrice),
@@ -137,6 +142,10 @@ function syncFiltersToUrl(filters, replace = false) {
 function applyFiltersFromUrl() {
   isApplyingUrlState = true
   activeFilters.value = readFiltersFromUrl()
+}
+
+function handleSearchChange() {
+  applyFiltersFromUrl()
 }
 
 function resolveApiUrl(url) {
@@ -224,12 +233,14 @@ function setupInfiniteScroll() {
 onMounted(() => {
   syncFiltersToUrl(activeFilters.value, true)
   window.addEventListener('popstate', applyFiltersFromUrl)
+  window.addEventListener('catalog-search-change', handleSearchChange)
   fetchProducts(productListUrl())
 })
 
 onBeforeUnmount(() => {
   observer?.disconnect()
   window.removeEventListener('popstate', applyFiltersFromUrl)
+  window.removeEventListener('catalog-search-change', handleSearchChange)
 })
 
 watch(() => props.selectedCategory?.slug, () => {

--- a/src/components/ProductListingPage.vue
+++ b/src/components/ProductListingPage.vue
@@ -10,6 +10,8 @@ const props = defineProps({
   },
 })
 
+const emit = defineEmits(['view-product'])
+
 const apiBaseUrl = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000'
 const products = ref([])
 const nextPageUrl = ref(null)
@@ -162,6 +164,7 @@ watch(() => props.selectedCategory?.slug, () => {
             v-for="product in products"
             :key="product.id"
             :product="product"
+            @view="emit('view-product', $event)"
           />
         </div>
 

--- a/src/components/ProductListingPage.vue
+++ b/src/components/ProductListingPage.vue
@@ -14,23 +14,26 @@ const props = defineProps({
 const emit = defineEmits(['view-product'])
 
 const apiBaseUrl = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000'
+const defaultFilters = {
+  brand: '',
+  category: '',
+  minPrice: 0,
+  maxPrice: 3000,
+}
+const filterParamKeys = ['brand', 'category', 'min_price', 'max_price']
 const products = ref([])
 const facets = ref({
   brands: [],
   price_ranges: [],
 })
-const activeFilters = ref({
-  brand: '',
-  category: '',
-  minPrice: 0,
-  maxPrice: 3000,
-})
+const activeFilters = ref(readFiltersFromUrl())
 const nextPageUrl = ref(null)
 const isLoading = ref(false)
 const isLoadingMore = ref(false)
 const errorMessage = ref('')
 const loadMoreMarker = ref(null)
 let observer = null
+let isApplyingUrlState = false
 
 const hasProducts = computed(() => products.value.length > 0)
 const pageTitle = computed(() => props.selectedCategory?.name || 'Product Catalog')
@@ -43,24 +46,97 @@ const pageSubtitle = computed(() => {
 })
 
 function productListUrl() {
-  const params = new URLSearchParams()
-
-  if (activeFilters.value.brand) {
-    params.set('brand', activeFilters.value.brand)
-  }
-  if (activeFilters.value.category) {
-    params.set('category', activeFilters.value.category)
-  }
-  if (Number(activeFilters.value.minPrice) > 0) {
-    params.set('min_price', activeFilters.value.minPrice)
-  }
-  if (Number(activeFilters.value.maxPrice) < 3000) {
-    params.set('max_price', activeFilters.value.maxPrice)
-  }
-
+  const params = filtersToSearchParams(activeFilters.value)
   const queryString = params.toString()
   const baseUrl = `${apiBaseUrl}/api/v1/catalog/products/search/`
   return queryString ? `${baseUrl}?${queryString}` : baseUrl
+}
+
+function filtersToSearchParams(filters) {
+  const params = new URLSearchParams()
+
+  if (filters.brand) {
+    params.set('brand', filters.brand)
+  }
+  if (filters.category) {
+    params.set('category', filters.category)
+  }
+  if (Number(filters.minPrice) > defaultFilters.minPrice) {
+    params.set('min_price', filters.minPrice)
+  }
+  if (Number(filters.maxPrice) < defaultFilters.maxPrice) {
+    params.set('max_price', filters.maxPrice)
+  }
+
+  return params
+}
+
+function normalizePrice(value, fallback) {
+  const numericValue = Number(value)
+
+  if (!Number.isFinite(numericValue)) {
+    return fallback
+  }
+
+  return Math.min(Math.max(numericValue, 0), defaultFilters.maxPrice)
+}
+
+function readFiltersFromUrl() {
+  if (typeof window === 'undefined') {
+    return { ...defaultFilters }
+  }
+
+  const params = new URLSearchParams(window.location.search)
+  const minPrice = normalizePrice(
+    params.get('min_price'),
+    defaultFilters.minPrice,
+  )
+  const maxPrice = normalizePrice(
+    params.get('max_price'),
+    defaultFilters.maxPrice,
+  )
+
+  return {
+    brand: params.get('brand') || defaultFilters.brand,
+    category: params.get('category') || defaultFilters.category,
+    minPrice: Math.min(minPrice, maxPrice),
+    maxPrice: Math.max(minPrice, maxPrice),
+  }
+}
+
+function syncFiltersToUrl(filters, replace = false) {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  const params = new URLSearchParams(window.location.search)
+  const filterParams = filtersToSearchParams(filters)
+
+  filterParamKeys.forEach((key) => {
+    params.delete(key)
+  })
+  filterParams.forEach((value, key) => {
+    params.set(key, value)
+  })
+
+  const queryString = params.toString()
+  const nextSearch = queryString ? `?${queryString}` : ''
+  const nextUrl = `${window.location.pathname}${nextSearch}${window.location.hash}`
+  const currentUrl = (
+    `${window.location.pathname}${window.location.search}${window.location.hash}`
+  )
+
+  if (nextUrl === currentUrl) {
+    return
+  }
+
+  const method = replace ? 'replaceState' : 'pushState'
+  window.history[method]({}, '', nextUrl)
+}
+
+function applyFiltersFromUrl() {
+  isApplyingUrlState = true
+  activeFilters.value = readFiltersFromUrl()
 }
 
 function resolveApiUrl(url) {
@@ -116,12 +192,7 @@ function loadFirstPage() {
 }
 
 function clearFilters() {
-  activeFilters.value = {
-    brand: '',
-    category: '',
-    minPrice: 0,
-    maxPrice: 3000,
-  }
+  activeFilters.value = { ...defaultFilters }
 }
 
 function loadNextPage() {
@@ -151,11 +222,14 @@ function setupInfiniteScroll() {
 }
 
 onMounted(() => {
+  syncFiltersToUrl(activeFilters.value, true)
+  window.addEventListener('popstate', applyFiltersFromUrl)
   fetchProducts(productListUrl())
 })
 
 onBeforeUnmount(() => {
   observer?.disconnect()
+  window.removeEventListener('popstate', applyFiltersFromUrl)
 })
 
 watch(() => props.selectedCategory?.slug, () => {
@@ -166,6 +240,12 @@ watch(() => props.selectedCategory?.slug, () => {
 })
 
 watch(activeFilters, () => {
+  if (isApplyingUrlState) {
+    isApplyingUrlState = false
+  } else {
+    syncFiltersToUrl(activeFilters.value)
+  }
+
   loadFirstPage()
 }, { deep: true })
 </script>

--- a/src/components/ProductListingPage.vue
+++ b/src/components/ProductListingPage.vue
@@ -1,0 +1,187 @@
+<script setup>
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+
+import ProductCard from './ProductCard.vue'
+
+const props = defineProps({
+  selectedCategory: {
+    type: Object,
+    default: null,
+  },
+})
+
+const apiBaseUrl = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000'
+const products = ref([])
+const nextPageUrl = ref(null)
+const isLoading = ref(false)
+const isLoadingMore = ref(false)
+const errorMessage = ref('')
+const loadMoreMarker = ref(null)
+let observer = null
+
+const hasProducts = computed(() => products.value.length > 0)
+const pageTitle = computed(() => props.selectedCategory?.name || 'Product Catalog')
+const pageSubtitle = computed(() => {
+  if (props.selectedCategory?.name) {
+    return `Browsing ${props.selectedCategory.name}`
+  }
+
+  return 'Browse the latest tech products in the catalog.'
+})
+
+function productListUrl() {
+  return `${apiBaseUrl}/api/v1/catalog/products/`
+}
+
+function resolveApiUrl(url) {
+  if (!url) {
+    return null
+  }
+
+  if (url.startsWith('http')) {
+    return url
+  }
+
+  return `${apiBaseUrl}${url}`
+}
+
+async function fetchProducts(url, append = false) {
+  if (isLoading.value || isLoadingMore.value) {
+    return
+  }
+
+  errorMessage.value = ''
+  isLoading.value = !append
+  isLoadingMore.value = append
+
+  try {
+    const response = await fetch(resolveApiUrl(url))
+
+    if (!response.ok) {
+      throw new Error('Could not load products.')
+    }
+
+    const payload = await response.json()
+    const nextProducts = payload.results || []
+
+    products.value = append ? [...products.value, ...nextProducts] : nextProducts
+    nextPageUrl.value = payload.next
+    await nextTick()
+    setupInfiniteScroll()
+  } catch (error) {
+    errorMessage.value = error.message || 'Could not load products.'
+  } finally {
+    isLoading.value = false
+    isLoadingMore.value = false
+  }
+}
+
+function loadFirstPage() {
+  products.value = []
+  nextPageUrl.value = null
+  fetchProducts(productListUrl())
+}
+
+function loadNextPage() {
+  if (!nextPageUrl.value) {
+    return
+  }
+
+  fetchProducts(nextPageUrl.value, true)
+}
+
+function setupInfiniteScroll() {
+  if (!loadMoreMarker.value || observer) {
+    return
+  }
+
+  observer = new IntersectionObserver(
+    ([entry]) => {
+      if (entry.isIntersecting && nextPageUrl.value) {
+        loadNextPage()
+      }
+    },
+    {
+      rootMargin: '320px 0px',
+    },
+  )
+  observer.observe(loadMoreMarker.value)
+}
+
+onMounted(() => {
+  fetchProducts(productListUrl())
+})
+
+onBeforeUnmount(() => {
+  observer?.disconnect()
+})
+
+watch(() => props.selectedCategory?.slug, () => {
+  loadFirstPage()
+})
+</script>
+
+<template>
+  <section class="min-w-0 flex-1 px-6 py-5">
+    <div class="flex flex-wrap items-center justify-between gap-4 border-b border-slate-200 pb-4">
+      <div>
+        <h1 class="text-xl font-semibold text-slate-950">
+          {{ pageTitle }}
+        </h1>
+        <p class="mt-1 text-sm text-slate-500">
+          {{ pageSubtitle }}
+        </p>
+      </div>
+
+      <div class="rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-sm font-medium text-slate-600">
+        {{ products.length }} loaded
+      </div>
+    </div>
+
+    <div class="py-5">
+      <div v-if="isLoading" class="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+        <div
+          v-for="item in 9"
+          :key="item"
+          class="h-80 animate-pulse rounded-md border border-slate-200 bg-slate-50"
+        ></div>
+      </div>
+
+      <div v-else-if="errorMessage" class="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+        {{ errorMessage }}
+      </div>
+
+      <div v-else-if="!hasProducts" class="rounded-md border border-slate-200 bg-slate-50 px-4 py-12 text-center">
+        <p class="text-sm font-semibold text-slate-700">No products found.</p>
+        <p class="mt-1 text-sm text-slate-500">Products will appear here after they are published.</p>
+      </div>
+
+      <template v-else>
+        <div class="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+          <ProductCard
+            v-for="product in products"
+            :key="product.id"
+            :product="product"
+          />
+        </div>
+
+        <div ref="loadMoreMarker" class="flex min-h-20 items-center justify-center py-6">
+          <div v-if="isLoadingMore" class="text-sm font-medium text-slate-500">
+            Loading more products...
+          </div>
+          <button
+            v-else-if="nextPageUrl"
+            type="button"
+            class="rounded-md border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-50"
+            @click="loadNextPage"
+          >
+            Load more
+          </button>
+          <p v-else class="text-sm text-slate-500">
+            End of catalog
+          </p>
+        </div>
+      </template>
+    </div>
+  </section>
+</template>

--- a/src/components/ProductListingPage.vue
+++ b/src/components/ProductListingPage.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 
+import FilterPanel from './FilterPanel.vue'
 import ProductCard from './ProductCard.vue'
 
 const props = defineProps({
@@ -14,6 +15,16 @@ const emit = defineEmits(['view-product'])
 
 const apiBaseUrl = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000'
 const products = ref([])
+const facets = ref({
+  brands: [],
+  price_ranges: [],
+})
+const activeFilters = ref({
+  brand: '',
+  category: '',
+  minPrice: 0,
+  maxPrice: 3000,
+})
 const nextPageUrl = ref(null)
 const isLoading = ref(false)
 const isLoadingMore = ref(false)
@@ -32,7 +43,24 @@ const pageSubtitle = computed(() => {
 })
 
 function productListUrl() {
-  return `${apiBaseUrl}/api/v1/catalog/products/`
+  const params = new URLSearchParams()
+
+  if (activeFilters.value.brand) {
+    params.set('brand', activeFilters.value.brand)
+  }
+  if (activeFilters.value.category) {
+    params.set('category', activeFilters.value.category)
+  }
+  if (Number(activeFilters.value.minPrice) > 0) {
+    params.set('min_price', activeFilters.value.minPrice)
+  }
+  if (Number(activeFilters.value.maxPrice) < 3000) {
+    params.set('max_price', activeFilters.value.maxPrice)
+  }
+
+  const queryString = params.toString()
+  const baseUrl = `${apiBaseUrl}/api/v1/catalog/products/search/`
+  return queryString ? `${baseUrl}?${queryString}` : baseUrl
 }
 
 function resolveApiUrl(url) {
@@ -67,6 +95,7 @@ async function fetchProducts(url, append = false) {
     const nextProducts = payload.results || []
 
     products.value = append ? [...products.value, ...nextProducts] : nextProducts
+    facets.value = payload.facets || facets.value
     nextPageUrl.value = payload.next
     await nextTick()
     setupInfiniteScroll()
@@ -81,7 +110,18 @@ async function fetchProducts(url, append = false) {
 function loadFirstPage() {
   products.value = []
   nextPageUrl.value = null
+  observer?.disconnect()
+  observer = null
   fetchProducts(productListUrl())
+}
+
+function clearFilters() {
+  activeFilters.value = {
+    brand: '',
+    category: '',
+    minPrice: 0,
+    maxPrice: 3000,
+  }
 }
 
 function loadNextPage() {
@@ -119,72 +159,87 @@ onBeforeUnmount(() => {
 })
 
 watch(() => props.selectedCategory?.slug, () => {
-  loadFirstPage()
+  activeFilters.value = {
+    ...activeFilters.value,
+    category: props.selectedCategory?.slug || '',
+  }
 })
+
+watch(activeFilters, () => {
+  loadFirstPage()
+}, { deep: true })
 </script>
 
 <template>
-  <section class="min-w-0 flex-1 px-6 py-5">
-    <div class="flex flex-wrap items-center justify-between gap-4 border-b border-slate-200 pb-4">
-      <div>
-        <h1 class="text-xl font-semibold text-slate-950">
-          {{ pageTitle }}
-        </h1>
-        <p class="mt-1 text-sm text-slate-500">
-          {{ pageSubtitle }}
-        </p>
-      </div>
+  <section class="flex min-w-0 flex-1 flex-col lg:flex-row">
+    <FilterPanel
+      v-model="activeFilters"
+      :facets="facets"
+      @clear="clearFilters"
+    />
 
-      <div class="rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-sm font-medium text-slate-600">
-        {{ products.length }} loaded
-      </div>
-    </div>
-
-    <div class="py-5">
-      <div v-if="isLoading" class="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
-        <div
-          v-for="item in 9"
-          :key="item"
-          class="h-80 animate-pulse rounded-md border border-slate-200 bg-slate-50"
-        ></div>
-      </div>
-
-      <div v-else-if="errorMessage" class="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
-        {{ errorMessage }}
-      </div>
-
-      <div v-else-if="!hasProducts" class="rounded-md border border-slate-200 bg-slate-50 px-4 py-12 text-center">
-        <p class="text-sm font-semibold text-slate-700">No products found.</p>
-        <p class="mt-1 text-sm text-slate-500">Products will appear here after they are published.</p>
-      </div>
-
-      <template v-else>
-        <div class="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
-          <ProductCard
-            v-for="product in products"
-            :key="product.id"
-            :product="product"
-            @view="emit('view-product', $event)"
-          />
-        </div>
-
-        <div ref="loadMoreMarker" class="flex min-h-20 items-center justify-center py-6">
-          <div v-if="isLoadingMore" class="text-sm font-medium text-slate-500">
-            Loading more products...
-          </div>
-          <button
-            v-else-if="nextPageUrl"
-            type="button"
-            class="rounded-md border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-50"
-            @click="loadNextPage"
-          >
-            Load more
-          </button>
-          <p v-else class="text-sm text-slate-500">
-            End of catalog
+    <div class="min-w-0 flex-1 px-6 py-5">
+      <div class="flex flex-wrap items-center justify-between gap-4 border-b border-slate-200 pb-4">
+        <div>
+          <h1 class="text-xl font-semibold text-slate-950">
+            {{ pageTitle }}
+          </h1>
+          <p class="mt-1 text-sm text-slate-500">
+            {{ pageSubtitle }}
           </p>
         </div>
-      </template>
+
+        <div class="rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-sm font-medium text-slate-600">
+          {{ products.length }} loaded
+        </div>
+      </div>
+
+      <div class="py-5">
+        <div v-if="isLoading" class="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+          <div
+            v-for="item in 9"
+            :key="item"
+            class="h-80 animate-pulse rounded-md border border-slate-200 bg-slate-50"
+          ></div>
+        </div>
+
+        <div v-else-if="errorMessage" class="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {{ errorMessage }}
+        </div>
+
+        <div v-else-if="!hasProducts" class="rounded-md border border-slate-200 bg-slate-50 px-4 py-12 text-center">
+          <p class="text-sm font-semibold text-slate-700">No products found.</p>
+          <p class="mt-1 text-sm text-slate-500">Products will appear here after they are published.</p>
+        </div>
+
+        <template v-else>
+          <div class="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+            <ProductCard
+              v-for="product in products"
+              :key="product.id"
+              :product="product"
+              @view="emit('view-product', $event)"
+            />
+          </div>
+
+          <div ref="loadMoreMarker" class="flex min-h-20 items-center justify-center py-6">
+            <div v-if="isLoadingMore" class="text-sm font-medium text-slate-500">
+              Loading more products...
+            </div>
+            <button
+              v-else-if="nextPageUrl"
+              type="button"
+              class="rounded-md border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-50"
+              @click="loadNextPage"
+            >
+              Load more
+            </button>
+            <p v-else class="text-sm text-slate-500">
+              End of catalog
+            </p>
+          </div>
+        </template>
+      </div>
     </div>
   </section>
 </template>

--- a/src/components/SearchBar.vue
+++ b/src/components/SearchBar.vue
@@ -1,0 +1,249 @@
+<script setup>
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+
+const apiBaseUrl = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000'
+const query = ref(readQueryFromUrl())
+const suggestions = ref([])
+const isLoading = ref(false)
+const errorMessage = ref('')
+const isOpen = ref(false)
+const selectedIndex = ref(-1)
+let debounceTimer = null
+let abortController = null
+let suppressNextSuggestionLoad = false
+
+const hasSuggestions = computed(() => suggestions.value.length > 0)
+
+function readQueryFromUrl() {
+  if (typeof window === 'undefined') {
+    return ''
+  }
+
+  return new URLSearchParams(window.location.search).get('q') || ''
+}
+
+function syncQueryToUrl(nextQuery) {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  const params = new URLSearchParams(window.location.search)
+  const cleanQuery = nextQuery.trim()
+
+  if (cleanQuery) {
+    params.set('q', cleanQuery)
+  } else {
+    params.delete('q')
+  }
+
+  const queryString = params.toString()
+  const nextSearch = queryString ? `?${queryString}` : ''
+  const nextUrl = `${window.location.pathname}${nextSearch}${window.location.hash}`
+  const currentUrl = (
+    `${window.location.pathname}${window.location.search}${window.location.hash}`
+  )
+
+  if (nextUrl !== currentUrl) {
+    window.history.pushState({}, '', nextUrl)
+  }
+
+  window.dispatchEvent(new CustomEvent('catalog-search-change'))
+}
+
+function resetDropdown() {
+  suggestions.value = []
+  selectedIndex.value = -1
+  isOpen.value = false
+}
+
+async function loadSuggestions(searchTerm) {
+  const cleanQuery = searchTerm.trim()
+
+  if (cleanQuery.length < 2) {
+    resetDropdown()
+    return
+  }
+
+  abortController?.abort()
+  abortController = new AbortController()
+  isLoading.value = true
+  errorMessage.value = ''
+
+  try {
+    const params = new URLSearchParams({ q: cleanQuery })
+    const response = await fetch(
+      `${apiBaseUrl}/api/v1/catalog/autocomplete/?${params.toString()}`,
+      { signal: abortController.signal },
+    )
+
+    if (!response.ok) {
+      throw new Error('Could not load suggestions.')
+    }
+
+    const payload = await response.json()
+    suggestions.value = payload.suggestions || []
+    selectedIndex.value = suggestions.value.length ? 0 : -1
+    isOpen.value = true
+  } catch (error) {
+    if (error.name !== 'AbortError') {
+      errorMessage.value = error.message || 'Could not load suggestions.'
+      suggestions.value = []
+      isOpen.value = true
+    }
+  } finally {
+    isLoading.value = false
+  }
+}
+
+function submitSearch(nextQuery = query.value) {
+  suppressNextSuggestionLoad = true
+  query.value = nextQuery
+  syncQueryToUrl(nextQuery)
+  resetDropdown()
+}
+
+function clearSearch() {
+  suppressNextSuggestionLoad = true
+  query.value = ''
+  syncQueryToUrl('')
+  resetDropdown()
+}
+
+function selectSuggestion(suggestion) {
+  submitSearch(suggestion)
+}
+
+function moveSelection(direction) {
+  if (!hasSuggestions.value) {
+    return
+  }
+
+  const lastIndex = suggestions.value.length - 1
+  if (direction === 'next') {
+    selectedIndex.value = (
+      selectedIndex.value >= lastIndex ? 0 : selectedIndex.value + 1
+    )
+  } else {
+    selectedIndex.value = (
+      selectedIndex.value <= 0 ? lastIndex : selectedIndex.value - 1
+    )
+  }
+}
+
+function handleEnter() {
+  if (isOpen.value && selectedIndex.value >= 0) {
+    selectSuggestion(suggestions.value[selectedIndex.value])
+    return
+  }
+
+  submitSearch()
+}
+
+function handleOutsideClick(event) {
+  if (
+    event.target instanceof Element
+    && !event.target.closest('[data-search-bar]')
+  ) {
+    isOpen.value = false
+  }
+}
+
+function handleUrlSearchChange() {
+  query.value = readQueryFromUrl()
+}
+
+watch(query, (nextQuery) => {
+  window.clearTimeout(debounceTimer)
+
+  if (suppressNextSuggestionLoad) {
+    suppressNextSuggestionLoad = false
+    return
+  }
+
+  debounceTimer = window.setTimeout(() => {
+    loadSuggestions(nextQuery)
+  }, 250)
+})
+
+onMounted(() => {
+  window.addEventListener('click', handleOutsideClick)
+  window.addEventListener('popstate', handleUrlSearchChange)
+})
+
+onBeforeUnmount(() => {
+  window.clearTimeout(debounceTimer)
+  abortController?.abort()
+  window.removeEventListener('click', handleOutsideClick)
+  window.removeEventListener('popstate', handleUrlSearchChange)
+})
+</script>
+
+<template>
+  <div data-search-bar class="relative w-full max-w-md">
+    <form
+      class="flex items-center rounded-md border border-slate-200 bg-white shadow-sm focus-within:border-slate-400"
+      @submit.prevent="submitSearch()"
+    >
+      <input
+        v-model="query"
+        type="search"
+        autocomplete="off"
+        class="min-w-0 flex-1 rounded-l-md px-3 py-2 text-sm text-slate-800 outline-none"
+        placeholder="Search products"
+        aria-label="Search products"
+        @focus="isOpen = Boolean(query.trim().length >= 2)"
+        @keydown.down.prevent="moveSelection('next')"
+        @keydown.up.prevent="moveSelection('previous')"
+        @keydown.enter.prevent="handleEnter"
+        @keydown.esc="isOpen = false"
+      >
+
+      <button
+        v-if="query"
+        type="button"
+        class="flex h-9 w-9 items-center justify-center text-slate-400 hover:text-slate-700"
+        aria-label="Clear search"
+        @click="clearSearch"
+      >
+        ×
+      </button>
+
+      <button
+        type="submit"
+        class="mr-1 rounded-md bg-slate-900 px-3 py-1.5 text-sm font-semibold text-white hover:bg-slate-700"
+      >
+        Search
+      </button>
+    </form>
+
+    <div
+      v-if="isOpen"
+      class="absolute left-0 right-0 top-full z-30 mt-2 overflow-hidden rounded-md border border-slate-200 bg-white shadow-lg"
+    >
+      <div v-if="isLoading" class="px-3 py-3 text-sm text-slate-500">
+        Loading suggestions...
+      </div>
+      <div v-else-if="errorMessage" class="px-3 py-3 text-sm text-red-600">
+        {{ errorMessage }}
+      </div>
+      <ul v-else-if="hasSuggestions" class="max-h-72 overflow-y-auto py-1">
+        <li
+          v-for="(suggestion, index) in suggestions"
+          :key="suggestion"
+        >
+          <button
+            type="button"
+            class="block w-full px-3 py-2 text-left text-sm text-slate-700 hover:bg-slate-50"
+            :class="{ 'bg-slate-100': index === selectedIndex }"
+            @mousedown.prevent="selectSuggestion(suggestion)"
+          >
+            {{ suggestion }}
+          </button>
+        </li>
+      </ul>
+      <div v-else class="px-3 py-3 text-sm text-slate-500">
+        No suggestions found.
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/components/Searchbar.vue
+++ b/src/components/Searchbar.vue
@@ -1,8 +1,0 @@
-<search>
-
-</search>
-
-<template>
-    <input type="text">
-
-</template>

--- a/src/components/VendorProductForm.vue
+++ b/src/components/VendorProductForm.vue
@@ -1,0 +1,105 @@
+<script setup>
+import { computed, ref } from 'vue'
+
+import VendorProductImageGallery from './VendorProductImageGallery.vue'
+
+const product = ref({
+  name: 'MacBook Air 13 M3',
+  slug: 'macbook-air-13-m3',
+  sku: 'MBA13-M3-256',
+  base_price: '1099.00',
+})
+
+const images = ref([
+  {
+    id: 1,
+    image: 'https://images.unsplash.com/photo-1517336714731-489689fd1ca8?auto=format&fit=crop&w=800&q=80',
+    thumbnail: 'https://images.unsplash.com/photo-1517336714731-489689fd1ca8?auto=format&fit=crop&w=300&q=80',
+    alt_text: 'MacBook laptop open on desk',
+    sort_order: 0,
+    is_primary: true,
+  },
+  {
+    id: 2,
+    image: 'https://images.unsplash.com/photo-1496181133206-80ce9b88a853?auto=format&fit=crop&w=800&q=80',
+    thumbnail: 'https://images.unsplash.com/photo-1496181133206-80ce9b88a853?auto=format&fit=crop&w=300&q=80',
+    alt_text: 'Laptop keyboard and screen',
+    sort_order: 1,
+    is_primary: false,
+  },
+  {
+    id: 3,
+    image: 'https://images.unsplash.com/photo-1541807084-5c52b6b3adef?auto=format&fit=crop&w=800&q=80',
+    thumbnail: 'https://images.unsplash.com/photo-1541807084-5c52b6b3adef?auto=format&fit=crop&w=300&q=80',
+    alt_text: 'Laptop with accessories',
+    sort_order: 2,
+    is_primary: false,
+  },
+])
+
+const reorderedPayload = computed(() => ({
+  images: images.value.map((image) => ({
+    id: image.id,
+    sort_order: image.sort_order,
+    alt_text: image.alt_text,
+    is_primary: image.is_primary,
+  })),
+}))
+</script>
+
+<template>
+  <form class="space-y-5">
+    <section class="rounded-md border border-slate-200 bg-white">
+      <div class="border-b border-slate-200 px-4 py-3">
+        <h2 class="text-sm font-semibold text-slate-950">Vendor product form</h2>
+      </div>
+
+      <div class="grid gap-4 p-4 md:grid-cols-2">
+        <label class="block">
+          <span class="text-xs font-medium text-slate-600">Name</span>
+          <input
+            v-model="product.name"
+            type="text"
+            class="mt-1 w-full rounded-md border border-slate-200 px-3 py-2 text-sm outline-none focus:border-slate-500"
+          >
+        </label>
+
+        <label class="block">
+          <span class="text-xs font-medium text-slate-600">Slug</span>
+          <input
+            v-model="product.slug"
+            type="text"
+            class="mt-1 w-full rounded-md border border-slate-200 px-3 py-2 text-sm outline-none focus:border-slate-500"
+          >
+        </label>
+
+        <label class="block">
+          <span class="text-xs font-medium text-slate-600">SKU</span>
+          <input
+            v-model="product.sku"
+            type="text"
+            class="mt-1 w-full rounded-md border border-slate-200 px-3 py-2 text-sm outline-none focus:border-slate-500"
+          >
+        </label>
+
+        <label class="block">
+          <span class="text-xs font-medium text-slate-600">Base price</span>
+          <input
+            v-model="product.base_price"
+            type="number"
+            min="0"
+            step="0.01"
+            class="mt-1 w-full rounded-md border border-slate-200 px-3 py-2 text-sm outline-none focus:border-slate-500"
+          >
+        </label>
+      </div>
+    </section>
+
+    <VendorProductImageGallery v-model="images" />
+
+    <section class="rounded-md border border-slate-200 bg-slate-950 p-4 text-slate-100">
+      <h2 class="text-sm font-semibold">PATCH reorder payload</h2>
+      <pre class="mt-3 max-h-64 overflow-auto rounded-md bg-black/30 p-3 text-xs leading-5">{{ JSON.stringify(reorderedPayload, null, 2) }}</pre>
+    </section>
+  </form>
+</template>

--- a/src/components/VendorProductForm.vue
+++ b/src/components/VendorProductForm.vue
@@ -1,15 +1,27 @@
 <script setup>
-import { computed, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 
 import VendorProductImageGallery from './VendorProductImageGallery.vue'
 
+const apiBaseUrl = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000'
+const mode = ref('create')
+const authToken = ref('')
+const targetSlug = ref('macbook-air-13-m3')
 const product = ref({
   name: 'MacBook Air 13 M3',
   slug: 'macbook-air-13-m3',
   sku: 'MBA13-M3-256',
+  brand: 1,
+  category: 1,
+  status: 'draft',
   base_price: '1099.00',
 })
-
+const specsJson = ref(JSON.stringify({
+  cpu: 'Apple M3',
+  ram: '16GB',
+  storage: '512GB SSD',
+  display: '13.6 inch Liquid Retina',
+}, null, 2))
 const images = ref([
   {
     id: 1,
@@ -36,8 +48,46 @@ const images = ref([
     is_primary: false,
   },
 ])
+const saveState = ref('idle')
+const responseMessage = ref('')
+const shouldShowPayload = ref(false)
 
-const reorderedPayload = computed(() => ({
+const endpointUrl = computed(() => {
+  if (mode.value === 'update') {
+    return `${apiBaseUrl}/api/v1/catalog/products/${targetSlug.value}/`
+  }
+
+  return `${apiBaseUrl}/api/v1/catalog/products/`
+})
+
+const requestMethod = computed(() => (mode.value === 'update' ? 'PUT' : 'POST'))
+
+const parsedSpecs = computed(() => {
+  try {
+    return {
+      value: JSON.parse(specsJson.value || '{}'),
+      error: '',
+    }
+  } catch (error) {
+    return {
+      value: null,
+      error: error.message,
+    }
+  }
+})
+
+const productPayload = computed(() => ({
+  name: product.value.name.trim(),
+  slug: product.value.slug.trim(),
+  sku: product.value.sku.trim(),
+  brand: Number(product.value.brand),
+  category: Number(product.value.category),
+  status: product.value.status,
+  base_price: product.value.base_price,
+  tech_specs: parsedSpecs.value.value,
+}))
+
+const reorderPayload = computed(() => ({
   images: images.value.map((image) => ({
     id: image.id,
     sort_order: image.sort_order,
@@ -45,61 +95,286 @@ const reorderedPayload = computed(() => ({
     is_primary: image.is_primary,
   })),
 }))
+
+const hasValidProductPayload = computed(() => {
+  return Boolean(
+    productPayload.value.name &&
+    productPayload.value.slug &&
+    productPayload.value.sku &&
+    productPayload.value.brand &&
+    productPayload.value.category &&
+    productPayload.value.base_price &&
+    parsedSpecs.value.value,
+  )
+})
+
+function formatSpecs() {
+  if (!parsedSpecs.value.value) {
+    return
+  }
+
+  specsJson.value = JSON.stringify(parsedSpecs.value.value, null, 2)
+}
+
+async function saveProduct() {
+  shouldShowPayload.value = true
+
+  if (!hasValidProductPayload.value) {
+    responseMessage.value = 'Fix the product fields before saving.'
+    return
+  }
+
+  saveState.value = 'saving'
+  responseMessage.value = ''
+
+  try {
+    const response = await fetch(endpointUrl.value, {
+      method: requestMethod.value,
+      headers: {
+        'Content-Type': 'application/json',
+        ...(authToken.value ? { Authorization: `Bearer ${authToken.value}` } : {}),
+      },
+      body: JSON.stringify(productPayload.value),
+    })
+
+    if (!response.ok) {
+      const errorPayload = await response.json().catch(() => ({}))
+      throw new Error(JSON.stringify(errorPayload, null, 2) || 'Could not save product.')
+    }
+
+    const savedProduct = await response.json()
+    product.value.slug = savedProduct.slug
+    targetSlug.value = savedProduct.slug
+    product.value.status = savedProduct.status
+    responseMessage.value = 'Product saved.'
+    saveState.value = 'saved'
+  } catch (error) {
+    responseMessage.value = error.message || 'Could not save product.'
+    saveState.value = 'error'
+  }
+}
+
+watch(mode, () => {
+  targetSlug.value = product.value.slug
+  responseMessage.value = ''
+  saveState.value = 'idle'
+})
 </script>
 
 <template>
-  <form class="space-y-5">
-    <section class="rounded-md border border-slate-200 bg-white">
-      <div class="border-b border-slate-200 px-4 py-3">
-        <h2 class="text-sm font-semibold text-slate-950">Vendor product form</h2>
+  <section class="min-w-0 flex-1 px-6 py-5">
+    <div class="flex flex-wrap items-center justify-between gap-4 border-b border-slate-200 pb-4">
+      <div>
+        <h1 class="text-xl font-semibold text-slate-950">
+          Product Management
+        </h1>
+        <p class="mt-1 text-sm text-slate-500">
+          Create and update catalog products for the current tenant.
+        </p>
       </div>
 
-      <div class="grid gap-4 p-4 md:grid-cols-2">
-        <label class="block">
-          <span class="text-xs font-medium text-slate-600">Name</span>
-          <input
-            v-model="product.name"
-            type="text"
-            class="mt-1 w-full rounded-md border border-slate-200 px-3 py-2 text-sm outline-none focus:border-slate-500"
-          >
-        </label>
-
-        <label class="block">
-          <span class="text-xs font-medium text-slate-600">Slug</span>
-          <input
-            v-model="product.slug"
-            type="text"
-            class="mt-1 w-full rounded-md border border-slate-200 px-3 py-2 text-sm outline-none focus:border-slate-500"
-          >
-        </label>
-
-        <label class="block">
-          <span class="text-xs font-medium text-slate-600">SKU</span>
-          <input
-            v-model="product.sku"
-            type="text"
-            class="mt-1 w-full rounded-md border border-slate-200 px-3 py-2 text-sm outline-none focus:border-slate-500"
-          >
-        </label>
-
-        <label class="block">
-          <span class="text-xs font-medium text-slate-600">Base price</span>
-          <input
-            v-model="product.base_price"
-            type="number"
-            min="0"
-            step="0.01"
-            class="mt-1 w-full rounded-md border border-slate-200 px-3 py-2 text-sm outline-none focus:border-slate-500"
-          >
-        </label>
+      <div class="inline-flex rounded-md border border-slate-200 bg-slate-50 p-1">
+        <button
+          type="button"
+          class="rounded px-3 py-1.5 text-sm font-semibold"
+          :class="mode === 'create' ? 'bg-white text-slate-950 shadow-sm' : 'text-slate-500 hover:text-slate-800'"
+          @click="mode = 'create'"
+        >
+          Create
+        </button>
+        <button
+          type="button"
+          class="rounded px-3 py-1.5 text-sm font-semibold"
+          :class="mode === 'update' ? 'bg-white text-slate-950 shadow-sm' : 'text-slate-500 hover:text-slate-800'"
+          @click="mode = 'update'"
+        >
+          Update
+        </button>
       </div>
-    </section>
+    </div>
 
-    <VendorProductImageGallery v-model="images" />
+    <form class="grid gap-5 py-5 xl:grid-cols-[minmax(0,1fr)_360px]" @submit.prevent="saveProduct">
+      <div class="space-y-5">
+        <section class="rounded-md border border-slate-200 bg-white">
+          <div class="border-b border-slate-200 px-4 py-3">
+            <h2 class="text-sm font-semibold text-slate-950">Product fields</h2>
+          </div>
 
-    <section class="rounded-md border border-slate-200 bg-slate-950 p-4 text-slate-100">
-      <h2 class="text-sm font-semibold">PATCH reorder payload</h2>
-      <pre class="mt-3 max-h-64 overflow-auto rounded-md bg-black/30 p-3 text-xs leading-5">{{ JSON.stringify(reorderedPayload, null, 2) }}</pre>
-    </section>
-  </form>
+          <div class="grid gap-4 p-4 md:grid-cols-2">
+            <label class="block">
+              <span class="text-xs font-medium text-slate-600">Name</span>
+              <input
+                v-model="product.name"
+                type="text"
+                class="mt-1 w-full rounded-md border border-slate-200 px-3 py-2 text-sm outline-none focus:border-slate-500"
+              >
+            </label>
+
+            <label class="block">
+              <span class="text-xs font-medium text-slate-600">Slug</span>
+              <input
+                v-model="product.slug"
+                type="text"
+                class="mt-1 w-full rounded-md border border-slate-200 px-3 py-2 text-sm outline-none focus:border-slate-500"
+              >
+            </label>
+
+            <label class="block">
+              <span class="text-xs font-medium text-slate-600">SKU</span>
+              <input
+                v-model="product.sku"
+                type="text"
+                class="mt-1 w-full rounded-md border border-slate-200 px-3 py-2 text-sm outline-none focus:border-slate-500"
+              >
+            </label>
+
+            <label class="block">
+              <span class="text-xs font-medium text-slate-600">Base price</span>
+              <input
+                v-model="product.base_price"
+                type="number"
+                min="0"
+                step="0.01"
+                class="mt-1 w-full rounded-md border border-slate-200 px-3 py-2 text-sm outline-none focus:border-slate-500"
+              >
+            </label>
+
+            <label class="block">
+              <span class="text-xs font-medium text-slate-600">Brand ID</span>
+              <input
+                v-model.number="product.brand"
+                type="number"
+                min="1"
+                class="mt-1 w-full rounded-md border border-slate-200 px-3 py-2 text-sm outline-none focus:border-slate-500"
+              >
+            </label>
+
+            <label class="block">
+              <span class="text-xs font-medium text-slate-600">Category ID</span>
+              <input
+                v-model.number="product.category"
+                type="number"
+                min="1"
+                class="mt-1 w-full rounded-md border border-slate-200 px-3 py-2 text-sm outline-none focus:border-slate-500"
+              >
+            </label>
+
+            <label class="block md:col-span-2">
+              <span class="text-xs font-medium text-slate-600">Status</span>
+              <select
+                v-model="product.status"
+                class="mt-1 w-full rounded-md border border-slate-200 px-3 py-2 text-sm outline-none focus:border-slate-500"
+              >
+                <option value="draft">Draft</option>
+                <option value="active">Active</option>
+                <option value="archived">Archived</option>
+              </select>
+            </label>
+          </div>
+        </section>
+
+        <section class="rounded-md border border-slate-200 bg-white">
+          <div class="flex flex-wrap items-center justify-between gap-3 border-b border-slate-200 px-4 py-3">
+            <h2 class="text-sm font-semibold text-slate-950">Tech specs JSON</h2>
+            <button
+              type="button"
+              class="rounded-md border border-slate-200 px-3 py-2 text-xs font-semibold text-slate-700 hover:bg-slate-50"
+              :disabled="Boolean(parsedSpecs.error)"
+              @click="formatSpecs"
+            >
+              Format JSON
+            </button>
+          </div>
+
+          <div class="p-4">
+            <textarea
+              v-model="specsJson"
+              spellcheck="false"
+              class="min-h-72 w-full resize-y rounded-md border bg-slate-950 p-4 font-mono text-sm leading-6 text-slate-100 outline-none focus:border-slate-500"
+              :class="parsedSpecs.error ? 'border-red-300' : 'border-slate-800'"
+            ></textarea>
+            <p
+              v-if="parsedSpecs.error"
+              class="mt-2 rounded-md bg-red-50 px-3 py-2 text-sm text-red-700"
+            >
+              {{ parsedSpecs.error }}
+            </p>
+          </div>
+        </section>
+
+        <VendorProductImageGallery v-model="images" />
+      </div>
+
+      <aside class="space-y-5">
+        <section class="rounded-md border border-slate-200 bg-white p-4">
+          <h2 class="text-sm font-semibold text-slate-950">Save product</h2>
+          <dl class="mt-4 space-y-3 text-sm">
+            <div v-if="mode === 'update'" class="space-y-1">
+              <dt class="text-slate-500">Current slug</dt>
+              <dd>
+                <input
+                  v-model="targetSlug"
+                  type="text"
+                  class="w-full rounded-md border border-slate-200 px-3 py-2 text-sm outline-none focus:border-slate-500"
+                >
+              </dd>
+            </div>
+            <div class="flex justify-between gap-3">
+              <dt class="text-slate-500">Method</dt>
+              <dd class="font-semibold text-slate-950">{{ requestMethod }}</dd>
+            </div>
+            <div class="space-y-1">
+              <dt class="text-slate-500">Endpoint</dt>
+              <dd class="break-all font-mono text-xs text-slate-700">{{ endpointUrl }}</dd>
+            </div>
+            <div class="space-y-1">
+              <dt class="text-slate-500">Bearer token</dt>
+              <dd>
+                <input
+                  v-model="authToken"
+                  type="password"
+                  class="w-full rounded-md border border-slate-200 px-3 py-2 text-sm outline-none focus:border-slate-500"
+                >
+              </dd>
+            </div>
+          </dl>
+
+          <button
+            type="submit"
+            class="mt-4 w-full rounded-md bg-slate-950 px-4 py-3 text-sm font-semibold text-white hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-300"
+            :disabled="saveState === 'saving' || !hasValidProductPayload"
+          >
+            {{ saveState === 'saving' ? 'Saving...' : 'Save product' }}
+          </button>
+
+          <p
+            v-if="responseMessage"
+            class="mt-3 rounded-md px-3 py-2 text-sm"
+            :class="saveState === 'error' ? 'bg-red-50 text-red-700' : 'bg-emerald-50 text-emerald-700'"
+          >
+            {{ responseMessage }}
+          </p>
+        </section>
+
+        <section class="rounded-md border border-slate-200 bg-slate-950 p-4 text-slate-100">
+          <div class="flex items-center justify-between gap-3">
+            <h2 class="text-sm font-semibold">Product payload</h2>
+            <button
+              type="button"
+              class="rounded-md border border-white/20 px-2 py-1 text-xs font-semibold text-slate-200 hover:bg-white/10"
+              @click="shouldShowPayload = !shouldShowPayload"
+            >
+              {{ shouldShowPayload ? 'Hide' : 'Show' }}
+            </button>
+          </div>
+          <pre v-if="shouldShowPayload" class="mt-3 max-h-80 overflow-auto rounded-md bg-black/30 p-3 text-xs leading-5">{{ JSON.stringify(productPayload, null, 2) }}</pre>
+        </section>
+
+        <section class="rounded-md border border-slate-200 bg-slate-950 p-4 text-slate-100">
+          <h2 class="text-sm font-semibold">Image reorder payload</h2>
+          <pre class="mt-3 max-h-64 overflow-auto rounded-md bg-black/30 p-3 text-xs leading-5">{{ JSON.stringify(reorderPayload, null, 2) }}</pre>
+        </section>
+      </aside>
+    </form>
+  </section>
 </template>

--- a/src/components/VendorProductImageGallery.vue
+++ b/src/components/VendorProductImageGallery.vue
@@ -1,0 +1,244 @@
+<script setup>
+import { computed, onBeforeUnmount, ref } from 'vue'
+
+const props = defineProps({
+  modelValue: {
+    type: Array,
+    default: () => [],
+  },
+})
+
+const emit = defineEmits([
+  'update:modelValue',
+  'reorder',
+  'remove',
+  'set-primary',
+  'upload',
+])
+
+const fileInput = ref(null)
+const draggedImageId = ref(null)
+const objectUrls = new Set()
+
+const sortedImages = computed(() => {
+  return [...props.modelValue].sort((first, second) => {
+    return first.sort_order - second.sort_order || first.id - second.id
+  })
+})
+
+function imageSource(image) {
+  return image.thumbnail || image.medium || image.image || image.previewUrl
+}
+
+function normalizeSortOrder(images) {
+  return images.map((image, index) => ({
+    ...image,
+    sort_order: index,
+  }))
+}
+
+function updateImages(images) {
+  const normalizedImages = normalizeSortOrder(images)
+  emit('update:modelValue', normalizedImages)
+  emit('reorder', normalizedImages)
+}
+
+function moveImage(targetImageId) {
+  if (!draggedImageId.value || draggedImageId.value === targetImageId) {
+    draggedImageId.value = null
+    return
+  }
+
+  const images = [...sortedImages.value]
+  const fromIndex = images.findIndex((image) => image.id === draggedImageId.value)
+  const toIndex = images.findIndex((image) => image.id === targetImageId)
+
+  if (fromIndex === -1 || toIndex === -1) {
+    draggedImageId.value = null
+    return
+  }
+
+  const [movedImage] = images.splice(fromIndex, 1)
+  images.splice(toIndex, 0, movedImage)
+  draggedImageId.value = null
+  updateImages(images)
+}
+
+function updateAltText(imageId, altText) {
+  const images = sortedImages.value.map((image) => {
+    if (image.id !== imageId) {
+      return image
+    }
+
+    return {
+      ...image,
+      alt_text: altText,
+    }
+  })
+
+  emit('update:modelValue', images)
+}
+
+function setPrimary(imageId) {
+  const images = sortedImages.value.map((image) => ({
+    ...image,
+    is_primary: image.id === imageId,
+  }))
+
+  emit('update:modelValue', images)
+  emit('set-primary', images.find((image) => image.id === imageId))
+}
+
+function removeImage(imageId) {
+  const imageToRemove = sortedImages.value.find((image) => image.id === imageId)
+  const images = normalizeSortOrder(sortedImages.value.filter((image) => image.id !== imageId))
+
+  if (imageToRemove?.previewUrl) {
+    URL.revokeObjectURL(imageToRemove.previewUrl)
+    objectUrls.delete(imageToRemove.previewUrl)
+  }
+
+  const hasPrimaryImage = images.some((image) => image.is_primary)
+  const nextImages = images.map((image, index) => ({
+    ...image,
+    is_primary: hasPrimaryImage ? image.is_primary : index === 0,
+  }))
+
+  emit('update:modelValue', nextImages)
+  emit('remove', imageToRemove)
+}
+
+function openFilePicker() {
+  fileInput.value?.click()
+}
+
+function handleFileSelection(event) {
+  const files = Array.from(event.target.files || [])
+  if (!files.length) {
+    return
+  }
+
+  const currentImages = sortedImages.value
+  const nextImages = files.map((file, index) => {
+    const previewUrl = URL.createObjectURL(file)
+    objectUrls.add(previewUrl)
+
+    return {
+      id: `local-${Date.now()}-${index}`,
+      file,
+      image: previewUrl,
+      previewUrl,
+      alt_text: file.name.replace(/\.[^.]+$/, '').replace(/[-_]/g, ' '),
+      sort_order: currentImages.length + index,
+      is_primary: currentImages.length === 0 && index === 0,
+    }
+  })
+
+  const images = normalizeSortOrder([...currentImages, ...nextImages])
+  emit('update:modelValue', images)
+  emit('upload', files)
+  event.target.value = ''
+}
+
+onBeforeUnmount(() => {
+  objectUrls.forEach((url) => URL.revokeObjectURL(url))
+})
+</script>
+
+<template>
+  <section class="rounded-md border border-slate-200 bg-white">
+    <div class="flex flex-wrap items-center justify-between gap-3 border-b border-slate-200 px-4 py-3">
+      <div>
+        <h2 class="text-sm font-semibold text-slate-950">Product images</h2>
+        <p class="mt-1 text-xs text-slate-500">
+          Drag images to reorder them.
+        </p>
+      </div>
+
+      <button
+        type="button"
+        class="rounded-md bg-slate-900 px-3 py-2 text-sm font-medium text-white hover:bg-slate-700"
+        @click="openFilePicker"
+      >
+        Upload images
+      </button>
+
+      <input
+        ref="fileInput"
+        type="file"
+        accept="image/*"
+        multiple
+        class="hidden"
+        @change="handleFileSelection"
+      >
+    </div>
+
+    <div v-if="!sortedImages.length" class="px-4 py-10 text-center">
+      <p class="text-sm font-medium text-slate-700">No images uploaded yet.</p>
+      <p class="mt-1 text-sm text-slate-500">Add product photos before publishing.</p>
+    </div>
+
+    <ul v-else class="grid gap-3 p-4 sm:grid-cols-2 xl:grid-cols-3">
+      <li
+        v-for="image in sortedImages"
+        :key="image.id"
+        draggable="true"
+        class="rounded-md border border-slate-200 bg-slate-50 transition hover:border-slate-300"
+        :class="{ 'ring-2 ring-slate-900': draggedImageId === image.id }"
+        @dragstart="draggedImageId = image.id"
+        @dragend="draggedImageId = null"
+        @dragover.prevent
+        @drop.prevent="moveImage(image.id)"
+      >
+        <div class="aspect-square overflow-hidden rounded-t-md bg-slate-100">
+          <img
+            :src="imageSource(image)"
+            :alt="image.alt_text || 'Product image'"
+            class="h-full w-full object-cover"
+          >
+        </div>
+
+        <div class="space-y-3 p-3">
+          <div class="flex items-center justify-between gap-2">
+            <span class="text-xs font-medium text-slate-500">
+              Order {{ image.sort_order + 1 }}
+            </span>
+            <span
+              v-if="image.is_primary"
+              class="rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-700"
+            >
+              Primary
+            </span>
+          </div>
+
+          <label class="block">
+            <span class="text-xs font-medium text-slate-600">Alt text</span>
+            <input
+              :value="image.alt_text"
+              type="text"
+              class="mt-1 w-full rounded-md border border-slate-200 bg-white px-2 py-2 text-sm outline-none focus:border-slate-500"
+              @input="updateAltText(image.id, $event.target.value)"
+            >
+          </label>
+
+          <div class="flex items-center gap-2">
+            <button
+              type="button"
+              class="flex-1 rounded-md border border-slate-200 px-2 py-2 text-sm font-medium text-slate-700 hover:bg-white"
+              @click="setPrimary(image.id)"
+            >
+              Set primary
+            </button>
+            <button
+              type="button"
+              class="rounded-md border border-red-200 px-2 py-2 text-sm font-medium text-red-700 hover:bg-red-50"
+              @click="removeImage(image.id)"
+            >
+              Remove
+            </button>
+          </div>
+        </div>
+      </li>
+    </ul>
+  </section>
+</template>


### PR DESCRIPTION
Implements Person 2 frontend scope for Epics 2.1, 2.2, and 2.3.

Changes included:
- Category tree sidebar with expandable nested categories
- Product listing page with product card grid and infinite scroll
- Product detail page with image gallery, specs tab, and add-to-cart CTA
- Reusable ProductCard component with price, rating, and wishlist toggle
- Vendor product management form with tech specs JSON editor
- Drag-to-reorder product image gallery for vendor product form
- FilterPanel with price, brand, and category filters
- URL-synced filter state for shareable filtered product URLs
- SearchBar with debounced autocomplete dropdown

Related tasks:
#186, #193, #201, #205, #206, #213, #228, #229, #234
